### PR TITLE
Create man directories if not present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ install: $(PROG)
 	@echo "a location of your choosing manually"
 	@echo "--------------------------------------------------"
 	@echo ""
+	mkdir -p /usr/man/man1
+	mkdir -p /usr/local/man/man1/
 	cp -f $(PROG) /usr/sbin/
 	cp -f $(PROG).1 /usr/man/man1/ || cp -f $(PROG).1 /usr/local/man/man1/
 


### PR DESCRIPTION
Currently on Amazon Linux, I am getting the following error when running `make install`:

```
[ec2-user@ip-10-47-6-126 httpry]$ sudo make install
--------------------------------------------------
Installing httpry into /usr/sbin/

You can move the Perl scripts and other tools to
a location of your choosing manually
--------------------------------------------------

cp -f httpry /usr/sbin/
cp -f httpry.1 /usr/man/man1/ || cp -f httpry.1 /usr/local/man/man1/
cp: cannot create regular file ‘/usr/man/man1/’: No such file or directory
cp: cannot create regular file ‘/usr/local/man/man1/’: No such file or directory
make: *** [install] Error 1
```

The `Makefile` assumes that the `man` directories are present when they in fact are not.

This PR creates the missing `man` directories so that `make install` runs through without error.